### PR TITLE
Remove redundant plan JSON script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
             <button id="next-week" class="nav-button">Next Week</button>
         </nav>
     </div>
-    <script src="data/plan.json"></script>
     <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove inline `<script>` tag loading `data/plan.json`, leaving only `script.js` before closing body.

## Testing
- `node <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a3ecdfc5d883269a4b25d826068bbb