### PR TITLE
Enhance UI with week selector and cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <div class="container">
         <header>
             <h1>Weekly Plan for Viraj</h1>
+            <select id="week-select" aria-label="Select week"></select>
         </header>
         <main id="plan-container"></main>
         <nav>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const pageTitle = document.querySelector('header h1');
     const prevWeekButton = document.getElementById('prev-week');
     const nextWeekButton = document.getElementById('next-week');
+    const weekSelect = document.getElementById('week-select');
 
     let currentWeek = 0;
     let weeklyData = [];
@@ -11,6 +12,15 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(response => response.json())
         .then(data => {
             weeklyData = data;
+
+            // Populate week selector
+            weeklyData.forEach((week, index) => {
+                const option = document.createElement('option');
+                const label = week['Week Number'] ? `Week ${week['Week Number']}` : `Week ${index + 1}`;
+                option.value = index;
+                option.textContent = label;
+                weekSelect.appendChild(option);
+            });
 
             // Find the current week based on today's date
             const today = new Date();
@@ -36,6 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
 
+            weekSelect.value = currentWeek;
             renderWeek(currentWeek);
         });
 
@@ -44,7 +55,8 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
         const weekData = weeklyData[weekIndex];
-        planContainer.innerHTML = ''; 
+        planContainer.innerHTML = '';
+        weekSelect.value = weekIndex;
 
         // Update the main title
         let titleText = "Weekly Plan for Viraj";
@@ -57,13 +69,16 @@ document.addEventListener('DOMContentLoaded', () => {
         pageTitle.textContent = titleText;
 
         const weekDiv = document.createElement('div');
-        weekDiv.className = 'week-plan';
+        weekDiv.className = 'week-plan fade-in';
 
         for (const key in weekData) {
             if (weekData.hasOwnProperty(key) && key !== 'Week Number' && key !== 'Week Dates' && weekData[key]) {
+                const section = document.createElement('section');
+                section.className = 'plan-section';
+
                 const title = document.createElement('h3');
                 title.textContent = key;
-                weekDiv.appendChild(title);
+                section.appendChild(title);
 
                 const contentValue = weekData[key];
                 if (key.startsWith('How to Teach / Impart') && typeof contentValue === 'string') {
@@ -74,7 +89,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         listItem.textContent = itemText.trim();
                         list.appendChild(listItem);
                     });
-                    weekDiv.appendChild(list);
+                    section.appendChild(list);
                 } else if (key === 'Trivia & GK Focus' && typeof contentValue === 'string') {
                     const list = document.createElement('ul');
                     const parts = contentValue.split(/:-/);
@@ -104,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             list.appendChild(listItem);
                         });
                     }
-                    weekDiv.appendChild(list);
+                    section.appendChild(list);
                 } else if (key.startsWith('Daily Rituals') && typeof contentValue === 'string') {
                     const list = document.createElement('ul');
                     const items = contentValue.split(/(Morning:|After school:|Evening:)/).filter(item => item.trim() !== '');
@@ -113,7 +128,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         listItem.innerHTML = `<strong>${items[i]}</strong> ${items[i+1]}`;
                         list.appendChild(listItem);
                     }
-                    weekDiv.appendChild(list);
+                    section.appendChild(list);
                 } else if (key.startsWith('Park Time Options') && typeof contentValue === 'string') {
                     const list = document.createElement('ul');
                     const items = contentValue.split(/\. |:/).filter(item => item.trim() !== '');
@@ -122,7 +137,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         listItem.textContent = itemText.trim();
                         list.appendChild(listItem);
                     });
-                    weekDiv.appendChild(list);
+                    section.appendChild(list);
                 } else if (key.startsWith('Trivia Bank') && typeof contentValue === 'string') {
                     const list = document.createElement('ol');
                     const items = contentValue.split(/\d+\./).filter(item => item.trim() !== '');
@@ -131,12 +146,13 @@ document.addEventListener('DOMContentLoaded', () => {
                         listItem.textContent = itemText.trim();
                         list.appendChild(listItem);
                     });
-                    weekDiv.appendChild(list);
+                    section.appendChild(list);
                 } else {
                     const content = document.createElement('p');
                     content.textContent = contentValue;
-                    weekDiv.appendChild(content);
+                    section.appendChild(content);
                 }
+                weekDiv.appendChild(section);
             }
         }
         planContainer.appendChild(weekDiv);
@@ -154,5 +170,10 @@ document.addEventListener('DOMContentLoaded', () => {
             currentWeek++;
             renderWeek(currentWeek);
         }
+    });
+
+    weekSelect.addEventListener('change', (e) => {
+        currentWeek = parseInt(e.target.value, 10);
+        renderWeek(currentWeek);
     });
 });

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 body {
     font-family: 'Poppins', sans-serif;
-    background-color: #f0f2f5;
+    background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
     color: #333;
     margin: 0;
     padding: 20px;
@@ -21,7 +21,9 @@ body {
 }
 
 header {
-    text-align: center;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     margin-bottom: 30px;
     border-bottom: 1px solid #e8e8e8;
     padding-bottom: 20px;
@@ -30,6 +32,14 @@ header {
 h1 {
     color: #2c3e50;
     font-weight: 600;
+}
+
+#week-select {
+    padding: 8px 12px;
+    border-radius: 6px;
+    border: 1px solid #ccc;
+    font-family: inherit;
+    background-color: #fff;
 }
 
 #plan-container {
@@ -65,6 +75,24 @@ h1 {
 
 .week-plan ul li {
     margin-bottom: 8px;
+}
+
+.plan-section {
+    background: #fdfdfd;
+    border: 1px solid #e5e5e5;
+    border-radius: 8px;
+    padding: 15px 20px;
+    margin-bottom: 20px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.04);
+}
+
+.fade-in {
+    animation: fadeIn 0.4s ease-in;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
 }
 
 nav {


### PR DESCRIPTION
## Summary
- Add week selector dropdown for quick navigation
- Apply gradient background and card-based layout with subtle animations
- Update script to populate selector and render plan sections in styled cards

## Testing
- `python -m py_compile plan.py`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3ee6691e08326916453d7d01a9a1f