### PR TITLE
Use date ranges for week selection and anchor layout at page top

### DIFF
--- a/script.js
+++ b/script.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
             // Populate week selector
             weeklyData.forEach((week, index) => {
                 const option = document.createElement('option');
-                const label = week['Week Number'] ? `Week ${week['Week Number']}` : `Week ${index + 1}`;
+                const label = week['Week Dates'] ? week['Week Dates'] : `Week ${index + 1}`;
                 option.value = index;
                 option.textContent = label;
                 weekSelect.appendChild(option);
@@ -60,9 +60,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Update the main title
         let titleText = "Weekly Plan for Viraj";
-        if (weekData['Week Number']) {
-            titleText += `: Week ${weekData['Week Number']}`;
-        }
         if (weekData['Week Dates']) {
             titleText += ` (${weekData['Week Dates']})`;
         }

--- a/style.css
+++ b/style.css
@@ -4,15 +4,12 @@ body {
     color: #333;
     margin: 0;
     padding: 20px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: 100vh;
 }
 
 .container {
     max-width: 800px;
     width: 100%;
+    margin: 0 auto;
     background: #ffffff;
     padding: 30px;
     border-radius: 12px;


### PR DESCRIPTION
## Summary
- Position content at the top of the page instead of centered
- Remove week numbers from header and show date ranges
- Populate week dropdown using date ranges

## Testing
- `node --check script.js`
- `python -m py_compile plan.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3f59732288326839c65ad943ef901